### PR TITLE
Fix for issue #11 by adding missing error message for policy violation

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/bamboo/tasks/HubScanTask.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/bamboo/tasks/HubScanTask.java
@@ -605,14 +605,17 @@ public class HubScanTask implements TaskType {
 				logger.error("Could not find any information about the Policy status of the bom.");
 				return resultBuilder.failed();
 			}
-			if (policyStatus.getOverallStatusEnum() == PolicyStatusEnum.IN_VIOLATION) {
-				return resultBuilder.failed();
-			}
 
 			if (policyStatus.getCountInViolation() == null) {
 				logger.error(createPolicyCountNotFound("In Violation"));
 			} else {
-				logger.info(createPolicyCountMessage(policyStatus.getCountInViolation().getValue(), "In Violation"));
+				final String inViolationMsg = createPolicyCountMessage(policyStatus.getCountInViolation().getValue(),
+						"In Violation");
+				if (policyStatus.getOverallStatusEnum() == PolicyStatusEnum.IN_VIOLATION) {
+					logger.error(inViolationMsg);
+				} else {
+					logger.info(inViolationMsg);
+				}
 			}
 			if (policyStatus.getCountInViolationOverridden() == null) {
 				logger.error(createPolicyCountNotFound("In Violation Overridden"));
@@ -625,6 +628,10 @@ public class HubScanTask implements TaskType {
 			} else {
 				logger.info(
 						createPolicyCountMessage(policyStatus.getCountNotInViolation().getValue(), "Not In Violation"));
+			}
+
+			if (policyStatus.getOverallStatusEnum() == PolicyStatusEnum.IN_VIOLATION) {
+				return resultBuilder.failedWithError();
 			}
 			return resultBuilder.success();
 		} catch (final MissingPolicyStatusException e) {


### PR DESCRIPTION
If the overall status is in violation then output the violation count as
an error rather than just info.  This ensures that it is displayed as an
error in the logs tab for the build without having to look at the
detailed log for the job.