### PR TITLE
fix for issue #13 check if username is set before setting proxy password

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/bamboo/HubBambooUtils.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/bamboo/HubBambooUtils.java
@@ -83,7 +83,6 @@ public class HubBambooUtils implements Cloneable {
 		configBuilder.setProxyHost(hubProxyUrl);
 		configBuilder.setProxyPort(hubProxyPort);
 		configBuilder.setProxyUsername(hubProxyUser);
-		configBuilder.setProxyPassword(hubProxyPass);
 
 		configBuilder.setIgnoredProxyHosts(hubProxyNoHost);
 		int length = 0;
@@ -92,9 +91,12 @@ public class HubBambooUtils implements Cloneable {
 			configBuilder.setPasswordLength(length);
 		}
 
-		if (StringUtils.isNotBlank(hubProxyPassLength)) {
-			length = Integer.valueOf(hubProxyPassLength);
-			configBuilder.setProxyPasswordLength(length);
+		if (StringUtils.isNotBlank(hubProxyUser)) {
+			configBuilder.setProxyPassword(hubProxyPass);
+			if (StringUtils.isNotBlank(hubProxyPassLength)) {
+				length = Integer.valueOf(hubProxyPassLength);
+				configBuilder.setProxyPasswordLength(length);
+			}
 		}
 		return configBuilder.build();
 	}


### PR DESCRIPTION
The proxy password and proxy password length is set even though the
proxy password information has been cleared to empty values.  Check if
the proxy username is set.  If it is set then set the proxy password
fields.  If it is blank do not set the proxy password fields.