### PR TITLE
Fix the table sorting of the risk report for Firefox and IE.

### DIFF
--- a/src/main/resources/js/HubBomReportFunctions.js
+++ b/src/main/resources/js/HubBomReportFunctions.js
@@ -286,30 +286,3 @@ function removeFilterFromRow(row, filterClassName) {
 		row.className = row.className.replace(filterClassName, "");
 	}
 }
-
-function reportStartup() {
-	var pageBody = document.getElementById("page-body");
-	if (pageBody) {
-		// If the element was found set the class name
-		pageBody.className += " pageBody";
-	}
-
-	adjustWidth(document.getElementById("highVulnerabilityRiskBar"));
-	adjustWidth(document.getElementById("mediumVulnerabilityRiskBar"));
-	adjustWidth(document.getElementById("lowVulnerabilityRiskBar"));
-	adjustWidth(document.getElementById("noVulnerabilityRiskBar"));
-
-	adjustWidth(document.getElementById("highLicenseRiskBar"));
-	adjustWidth(document.getElementById("mediumLicenseRiskBar"));
-	adjustWidth(document.getElementById("lowLicenseRiskBar"));
-	adjustWidth(document.getElementById("noLicenseRiskBar"));
-
-	adjustWidth(document.getElementById("highOperationalRiskBar"));
-	adjustWidth(document.getElementById("mediumOperationalRiskBar"));
-	adjustWidth(document.getElementById("lowOperationalRiskBar"));
-	adjustWidth(document.getElementById("noOperationalRiskBar"));
-
-	adjustTable();
-}
-
-reportStartup();

--- a/src/main/resources/js/HubReportStartup.js
+++ b/src/main/resources/js/HubReportStartup.js
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+var pageBody = document.getElementById("page-body");
+if (pageBody) {
+	// If the element was found set the class name
+	pageBody.className += " pageBody";
+}
+
+adjustWidth(document.getElementById("highVulnerabilityRiskBar"));
+adjustWidth(document.getElementById("mediumVulnerabilityRiskBar"));
+adjustWidth(document.getElementById("lowVulnerabilityRiskBar"));
+adjustWidth(document.getElementById("noVulnerabilityRiskBar"));
+
+adjustWidth(document.getElementById("highLicenseRiskBar"));
+adjustWidth(document.getElementById("mediumLicenseRiskBar"));
+adjustWidth(document.getElementById("lowLicenseRiskBar"));
+adjustWidth(document.getElementById("noLicenseRiskBar"));
+
+adjustWidth(document.getElementById("highOperationalRiskBar"));
+adjustWidth(document.getElementById("mediumOperationalRiskBar"));
+adjustWidth(document.getElementById("lowOperationalRiskBar"));
+adjustWidth(document.getElementById("noOperationalRiskBar"));
+
+adjustTable();
+sorttable.init();

--- a/src/main/resources/reports/viewHubRiskReport.ftl
+++ b/src/main/resources/reports/viewHubRiskReport.ftl
@@ -25,7 +25,6 @@ under the License.
 
 <link href="${pluginResourcesPath}css/HubBomReport.css" rel="stylesheet" type="text/css" />
 <link href="${pluginResourcesPath}font-awesome-4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
-<script type="text/javascript" src="${pluginResourcesPath}js/Sortable.js"></script>
 
 <div class="riskReportBackgroundColor">
     <div class="reportHeader">
@@ -284,4 +283,17 @@ under the License.
         </tbody>
     </table>
 </div>
-<script type="text/javascript" src="${pluginResourcesPath}js/HubBomReportFunctions.js"></script>       
+<script type="text/javascript">
+
+    ['${pluginResourcesPath}js/Sortable.js',
+     '${pluginResourcesPath}js/HubBomReportFunctions.js',
+     '${pluginResourcesPath}js/HubReportStartup.js'
+    ].forEach(function (src) {
+       var script = document.createElement('script');
+       script.type="text/javascript";
+       script.src = src; 
+       script.async = false;
+       document.head.appendChild(script);
+    });
+
+</script>  


### PR DESCRIPTION
Make the javascript consistent with teamcity by adding the
HubReportStartup.js file.  Add a call to sorttable.init() in
HubReportStartup.js in order to initialize the table for sorting.  Use
another technique to load the javascript used by the risk report to
ensure the page elements are rendered.